### PR TITLE
Fix for an issue with file URLs on Windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -202,7 +202,14 @@
             var done = decanonicalize.call(this, name, id);
 
             if (/^intern\//.test(name)) {
-                done = done.replace(/^file:\/\//, '');
+                // remove absolute file urls with drive letters in Windows (i.e., file:///C:\...)
+                if (/^file:\/{3}\w:/.test(done)) {
+                    done = done.replace(/^file:\/{3}/, '');
+                }
+                else {
+                    // remove non-windows, or relative, file urls
+                    done = done.replace(/^file:\/\//, '');
+                }
             }
 
             return done;


### PR DESCRIPTION
It looks like when generating the path to Intern on Windows, `file://` URLs are not being stripped correctly.

Example,

`file:///C:\absolute\path\to\intern` is being stripped to `/C:\absolute\path\to\intern`.

This change simply tests to see if the URL is a Windows absolute file url and if so, strips off 3 slashes instead of 2.